### PR TITLE
Add delay_up option to bond

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ It is configured by setting `netconf` for the host, there are the following opti
 * bond: Bonding interface: Like `if`, but additionally has:
   * slaves: List of slave interfaces
   * bondmode *(optional)*: Bond operation mode, per default 802.3ad (aka LACP) is used
+  * delay_up: *(optional)*: Add a delay in post-up to allow for the bond device to settle before attempting DAD etc.
 * vlan: VLAN interface. The name is the vlan id, configuration is like `if`, additionally the following is required:
   * parent: Interface this VLAN should be created on
 * rt: Extra routing tables. Maps from name to number
@@ -40,6 +41,7 @@ netconf:
       gateway: 82.130.108.193
       dnssearch: sos.ethz.ch
       dns: 129.132.250.2
+      delay_up: True
   vlan:
     2522:
       parent: bond0

--- a/templates/bond.j2
+++ b/templates/bond.j2
@@ -21,7 +21,7 @@ iface {{ item.key }} inet {{ ipmode }}
         bond_xmit_hash_policy layer3+4
         bond_miimon 100
         bond_lacp-rate 1
-        post-up echo 1000 > /sys/class/net/{{ item.key }}/bonding/ad_actor_sys_prio
+        post-up {{ 'sleep 20 && ' if 'delay_up' in item.value and item.value.delay_up }}echo 1000 > /sys/class/net/{{ item.key }}/bonding/ad_actor_sys_prio
 {% endif %}
 {% else %}
 auto {{ item.key }}br


### PR DESCRIPTION
It can happens that the bond device due to LACP negotiation
doesn't come up fast enough and several following tasks fail
(DAD, networking.service in failed state).

Add options to add a 20 sec delay to allow for the device to settle
before continuing.